### PR TITLE
Parse replication doc inside replicator

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 
 % public API
--export([replicate/1]).
+-export([replicate/2]).
 
 % meant to be used only by the replicator database listener
 -export([async_replicate/1]).
@@ -74,7 +74,9 @@
 }).
 
 
-replicate(#rep{id = RepId, options = Options, user_ctx = UserCtx} = Rep) ->
+replicate(PostBody, Ctx) ->
+    {ok, #rep{id = RepId, options = Options, user_ctx = UserCtx} = Rep} =
+        couch_replicator_utils:parse_rep_doc(PostBody, Ctx),
     case get_value(cancel, Options, false) of
     true ->
         case get_value(id, Options, nil) of

--- a/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator_httpd.erl
@@ -31,8 +31,7 @@ handle_req(#httpd{method = 'POST', user_ctx = UserCtx} = Req) ->
     couch_httpd:validate_ctype(Req, "application/json"),
     RepDoc = {Props} = couch_httpd:json_body_obj(Req),
     validate_rep_props(Props),
-    {ok, Rep} = couch_replicator_utils:parse_rep_doc(RepDoc, UserCtx),
-    case couch_replicator:replicate(Rep) of
+    case couch_replicator:replicate(RepDoc, UserCtx) of
     {error, {Error, Reason}} ->
         send_json(
             Req, 404,


### PR DESCRIPTION
This is to ensure that gethostname is run on the node running
the replication, as it becomes part of the replication id

NOTE: This requires a PR from chttpd-cloudant.com
