### PR TITLE
14273 repl source missing

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -470,7 +470,8 @@ terminate(shutdown, {error, Class, Error, Stack, InitArgs}) ->
     _ ->
         NotifyError = Error
     end,
-    couch_replicator_notifier:notify({error, RepId, NotifyError}).
+    couch_replicator_notifier:notify({error, RepId, NotifyError}),
+    couch_replicator_manager:replication_error(InitArgs, NotifyError).
 
 terminate_cleanup(State) ->
     update_task(State),


### PR DESCRIPTION
Fixed nit in call to twig:log that caused replication errors to not bubble up, and improved propagation of errors. 

Note: this requires the branch of the same name in chttpd
