### PR TITLE
Fixes for edge cases where replication doesn't start

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -259,7 +259,7 @@ changes_feed_loop(DbName, Since) ->
             nil,
             #changes_args{
                 include_docs = true,
-                feed = "normal",
+                feed = "longpoll",
                 since = Since,
                 filter = main_only,
                 timeout = infinity


### PR DESCRIPTION
I"m fairly certain that the occasional failures of replication docs to trigger is caused by the changes feed not having seen the updates when the doc is added. A simple sleep suffices as a workaround.

The other change is an edge case, deleting and recreating the _replicator db fails to update the internal table and also results in replication docs failing to trigger
