### PR TITLE
2xx is success

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -80,7 +80,7 @@ process_response({ibrowse_req_id, ReqId}, Worker, HttpDb, Params, Callback) ->
 process_response({ok, Code, Headers, Body}, Worker, HttpDb, Params, Callback) ->
     release_worker(Worker, HttpDb),
     case list_to_integer(Code) of
-    Ok when Ok =:= 200 ; Ok =:= 201 ; (Ok >= 400 andalso Ok < 500) ->
+    Ok when (Ok >= 200 andalso Ok < 300) ; (Ok >= 400 andalso Ok < 500) ->
         EJson = case Body of
         <<>> ->
             null;


### PR DESCRIPTION
The replicator would retry a write if it got a 202. The replicator
should consider all 2xx codes as successful.

BugzID: 15208
