### PR TITLE
Workaround for replication tasks involving attachments

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -799,7 +799,7 @@ update_checkpoint(Db, Doc, DbType) ->
 
 update_checkpoint(Db, #doc{id = LogId, body = LogBody} = Doc) ->
     try
-        case couch_replicator_api_wrap:update_doc(Db, Doc, [delay_commit]) of
+        case couch_replicator_api_wrap:update_doc(Db, Doc, [delay_commit], true) of
         {ok, PosRevId} ->
             PosRevId;
         {error, Reason} ->


### PR DESCRIPTION
couch_replication_worker:fetch_doc makes a call to api_wrap:open_revs, passing it
a `DocHandler`, which in the case of docs with attachments results in a call to
`flush_doc` which then calls api_wrap:update_doc. When attachments are present, the
doc returned from `open_revs` has a streaming function that's used by `update_doc`
to retrieve the actual attachment. In some cases this streaming function will
succeed but the api_wrap:update_doc call fails, resulting in a retry of
`couch_replicator_httpc:send_req` which hangs as the stream function is no longer valid.

This happens for any kind of fail in the update, 500, timeout, etc. Unfortunately the retry
logic is pretty low in the path, in a function called by many other functions in the api. This patch
introduces a new boolean parameter, RetryLocally, which is used to distinguish whether of not to
retry or throw a retry exception and handle the retry in the worker where the `fetch_doc` is
executed.

BugzID: 16253
