### PR TITLE
Allow the use of checkpoint to be optional

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -70,7 +70,8 @@
     target_db_compaction_notifier = nil,
     source_monitor = nil,
     target_monitor = nil,
-    source_seq = nil
+    source_seq = nil,
+    use_checkpoints = true
 }).
 
 
@@ -431,6 +432,8 @@ handle_cast({report_seq, Seq},
     {noreply, State#rep_state{seqs_in_progress = NewSeqsInProgress}}.
 
 
+code_change(_OldVsn, OldState, _Extra) when tuple_size(OldState) =:= 30 ->
+    {ok, erlang:append_element(OldState, true)};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
@@ -553,7 +556,8 @@ init_state(Rep) ->
             start_db_compaction_notifier(Target, self()),
         source_monitor = db_monitor(Source),
         target_monitor = db_monitor(Target),
-        source_seq = get_value(<<"update_seq">>, SourceInfo, ?LOWEST_SEQ)
+        source_seq = get_value(<<"update_seq">>, SourceInfo, ?LOWEST_SEQ),
+        use_checkpoints = get_value(use_checkpoints, Options, true)
     },
     State#rep_state{timer = start_timer(State)}.
 
@@ -662,6 +666,9 @@ changes_manager_loop_open(Parent, ChangesQueue, BatchSize, Ts) ->
 checkpoint_interval(_State) ->
     5000.
 
+do_checkpoint(#rep_state{use_checkpoints=false} = State) ->
+    NewState = State#rep_state{checkpoint_history = {[{<<"use_checkpoints">>, false}]} },
+    {ok, NewState};
 do_checkpoint(#rep_state{current_through_seq=Seq, committed_seq=Seq} = State) ->
     SourceCurSeq = source_cur_seq(State),
     NewState = State#rep_state{source_seq = SourceCurSeq},

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -223,6 +223,7 @@ make_options(Props) ->
     DefConns = couch_config:get("replicator", "http_connections", "20"),
     DefTimeout = couch_config:get("replicator", "connection_timeout", "30000"),
     DefRetries = couch_config:get("replicator", "retries_per_request", "10"),
+    UseCheckpoints = couch_config:get("replicator", "use_checkpoints", "true"),
     {ok, DefSocketOptions} = couch_util:parse_term(
         couch_config:get("replicator", "socket_options",
             "[{keepalive, true}, {nodelay, false}]")),
@@ -232,7 +233,8 @@ make_options(Props) ->
         {http_connections, list_to_integer(DefConns)},
         {socket_options, DefSocketOptions},
         {worker_batch_size, list_to_integer(DefBatchSize)},
-        {worker_processes, list_to_integer(DefWorkers)}
+        {worker_processes, list_to_integer(DefWorkers)},
+        {use_checkpoints, list_to_existing_atom(UseCheckpoints)}
     ])).
 
 
@@ -274,6 +276,8 @@ convert_options([{<<"socket_options">>, V} | R]) ->
     [{socket_options, SocketOptions} | convert_options(R)];
 convert_options([{<<"since_seq">>, V} | R]) ->
     [{since_seq, V} | convert_options(R)];
+convert_options([{<<"use_checkpoints">>, V} | R]) ->
+    [{use_checkpoints, V} | convert_options(R)];
 convert_options([_ | R]) -> % skip unknown option
     convert_options(R).
 


### PR DESCRIPTION
A new parameter use_checkpoints which defaults to be true can be either used in the replicator section of
ini files and/or used in the replication command or doc added to the replicator db. When this option is set
to false no checkpoints are taken. It should be used with caution and only for small dbs.

BugzID:14327
