### PR TITLE
Teach replicator to gracefully reconnect

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -639,7 +639,21 @@ read_changes(StartSeq, Db, ChangesQueue, Options) ->
                 _ ->
                     ok = couch_work_queue:queue(ChangesQueue, DocInfo)
                 end,
-                put(last_seq, Seq)
+                put(last_seq, Seq);
+            ({last_seq, LS}) ->
+                case get_value(continuous, Options) of
+                true ->
+                    % LS should never be undefined, but it doesn't hurt to be
+                    % defensive inside the replicator.
+                    Seq = case LS of undefined -> get(last_seq); _ -> LS end,
+                    read_changes(Seq, Db, ChangesQueue, Options);
+                _ ->
+                    % This clause is unreachable today, but let's plan ahead
+                    % for the future where we checkpoint against last_seq
+                    % instead of the sequence of the last change.  The two can
+                    % differ substantially in the case of a restrictive filter.
+                    ok
+                end
             end, Options),
         couch_work_queue:close(ChangesQueue)
     catch exit:{http_request_failed, _, _, _} = Error ->

--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -690,17 +690,22 @@ parse_changes_line(object_start, UserFun) ->
     end.
 
 json_to_doc_info({Props}) ->
-    RevsInfo = lists:map(
-        fun({Change}) ->
-            Rev = couch_doc:parse_rev(get_value(<<"rev">>, Change)),
-            Del = couch_replicator_utils:is_deleted(Change),
-            #rev_info{rev=Rev, deleted=Del}
-        end, get_value(<<"changes">>, Props)),
-    #doc_info{
-        id = get_value(<<"id">>, Props),
-        high_seq = get_value(<<"seq">>, Props),
-        revs = RevsInfo
-    }.
+    case get_value(<<"changes">>, Props) of
+    undefined ->
+        {last_seq, get_value(<<"last_seq">>, Props)};
+    Changes ->
+        RevsInfo = lists:map(
+            fun({Change}) ->
+                Rev = couch_doc:parse_rev(get_value(<<"rev">>, Change)),
+                Del = couch_replicator_utils:is_deleted(Change),
+                #rev_info{rev=Rev, deleted=Del}
+            end, Changes),
+        #doc_info{
+            id = get_value(<<"id">>, Props),
+            high_seq = get_value(<<"seq">>, Props),
+            revs = RevsInfo
+        }
+    end.
 
 
 bulk_results_to_errors(Docs, {ok, Results}, interactive_edit) ->


### PR DESCRIPTION
This patch allows the replicator to recognize the "last_seq" field at the end of a continuous _changes feed and reconnect to the feed using that value.

BugzID: 17502
