### PR TITLE
Don't add undefined stats to body

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -567,7 +567,9 @@ update_rep_doc(RepDbName, RepDocId, KVs) when is_binary(RepDocId) ->
 
 update_rep_doc(RepDbName, #doc{body = {RepDocBody}} = RepDoc, KVs) ->
     NewRepDocBody = lists:foldl(
-        fun({<<"_replication_state">> = K, State} = KV, Body) ->
+        fun({K, undefined}, Body) ->
+                lists:keydelete(K, 1, Body);
+           ({<<"_replication_state">> = K, State} = KV, Body) ->
                 case get_value(K, Body) of
                 State ->
                     Body;


### PR DESCRIPTION
We missed this somehow. Until a replication completes, the rep_doc does not get _replication_stats. CouchDB has a guard clause to remove undefined values, this patch restores it.
