### PR TITLE
Allow last_seq through doc_ids check

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -361,7 +361,9 @@ changes_since(#httpdb{headers = Headers1, timeout = InactiveTimeout} = HttpDb,
                                 UserFun(DocInfo);
                             false ->
                                 ok
-                            end
+                            end;
+                        (LastSeq) ->
+                            UserFun(LastSeq)
                         end,
                         parse_changes_feed(Options, UserFun2, DataStreamFun2)
                     end)


### PR DESCRIPTION
This is causing the replicator's changes feed processes to crash instead of reconnect.

BugzID: 17898
BugzID: 17840
