### PR TITLE
Increase dt between heartbeat and inactive timeouts

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -321,7 +321,7 @@ update_docs(Db, DocList, Options, UpdateType) ->
 
 changes_since(#httpdb{headers = Headers1, timeout = InactiveTimeout} = HttpDb,
               Style, StartSeq, UserFun, Options) ->
-    Timeout = erlang:max(1000, InactiveTimeout - 5000),
+    Timeout = erlang:max(1000, InactiveTimeout div 3),
     BaseQArgs = case get_value(continuous, Options, false) of
     false ->
         [{"feed", "normal"}];


### PR DESCRIPTION
The current theory is that on occasion the inactivity timeout in the ibrowse client fires before the replicator receives a heartbeat line.  This patch replaces the 5 second delta with the "div 3" logic that results in a 20 second delta by default.  This is the logic that we used back when the replicator used heartbeats instead of timeouts to control the frequency of heartbeat lines.

As an aside, the timeout value we're adjusting here actually serves a dual purpose.  When a _changes response is streaming this parameter controls the frequency of heartbeat newlines, useful e.g. for highly selective filtered feeds.  In between streams of _changes it controls how long the _changes coordinator will wait for updates to the DB before terminating the response with a last_seq entry.

BugzID: 17709
