### PR TITLE
Identify duped _replicator docs, report orig. ID

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -437,7 +437,7 @@ parse_rep_doc(RepDoc) ->
 
 duplicated_rep_doc(DbName, DocId, {RepProps}, RepId, OtherDocId) ->
     OldRepId = get_value(<<"_replication_id">>, RepProps),
-    OldState = get_value(<<"_replicaiton_state">>, RepProps),
+    OldState = get_value(<<"_replication_state">>, RepProps),
     OldStats = get_value(<<"_replication_stats">>, RepProps),
     case {OldRepId, OldState, OldStats} of
     {RepId, <<"duplicate">>, {[{<<"original_docid">>, OtherDocId}]}} ->

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -352,6 +352,8 @@ process_update(State, DbName, {Change}) ->
             maybe_start_replication(State, DbName, DocId, JsonRepDoc);
         <<"triggered">> ->
             maybe_start_replication(State, DbName, DocId, JsonRepDoc);
+        <<"duplicate">> ->
+            maybe_start_replication(State, DbName, DocId, JsonRepDoc);
         <<"completed">> ->
             replication_complete(DbName, DocId),
             State;


### PR DESCRIPTION
Before this patch a duplicate _replicator doc would have a _replication_id field and nothing else.  This just adds a bit more detail by setting the _replication_state to "duplicate" and reporting the ID of the _replicator document that is considered canonical in the _replication_stats.

A potential side effect here is that we lose previous state and stats for the case where a replication was once canonical.  E.g., if I load replication "B" and then later load "A" as a duplicate of "B", and the server restarts, "A" will pick up the updates and "B" will be re-labeled a duplicate.  Not sure if that's a bug or a feature.

BugzID: 18580
