### PR TITLE
Cancel replication jobs on every node, not just owner node

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -340,11 +340,10 @@ process_update(State, DbName, {Change}) ->
     {RepProps} = JsonRepDoc = get_value(doc, Change),
     DocId = get_value(<<"_id">>, RepProps),
     case {mem3_util:owner(DbName, DocId), get_value(deleted, Change, false)} of
-    {false, _} ->
-        replication_complete(DbName, DocId),
-        State;
-    {true, true} ->
+    {_, true} ->
         rep_doc_deleted(DbName, DocId),
+        State;
+    {false, false} ->
         State;
     {true, false} ->
         case get_value(<<"_replication_state">>, RepProps) of


### PR DESCRIPTION
It is safe to attempt to cancel a job owned by another node, just in
case ownership changed at the same time as the document was deleted.

BugzID: 19518
