### PR TITLE
Fix replication checkpoint frequency

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -650,7 +650,11 @@ read_changes(Parent, StartSeq, Db, ChangesQueue, Options, Ts) ->
                     % LS should never be undefined, but it doesn't hurt to be
                     % defensive inside the replicator.
                     Seq = case LS of undefined -> get(last_seq); _ -> LS end,
-                    ok = gen_server:call(Parent, {report_seq_done, {Ts, Seq}, #rep_stats{}}, infinity),
+                    OldSeq = get(last_seq),
+                    if Seq == OldSeq -> ok; true ->
+                        Msg = {report_seq_done, {Ts, Seq}, #rep_stats{}},
+                        ok = gen_server:call(Parent, Msg, infinity)
+                    end,
                     put(last_seq, Seq),
                     read_changes(Parent, Seq, Db, ChangesQueue, Options, Ts + 1);
                 _ ->


### PR DESCRIPTION
The patch to track and checkpoint last_seq values seen in the _changes
feed resulted in high frequency updates to the checkpoint document. This
is because the comparison made for "needs a checkpoint" was including
the replicator's incrementing counter which the changes reader was
bumping each time it saw last_seq even if it was the same last_seq as
the previous time.

This just compares the new last_seq value to the old last_seq value and
if they're equal then skips notifying the replication manager so that no
superfluous checkpoint is made.
