### PR TITLE
Make replication request timeout configurable

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -61,8 +61,12 @@ send_ibrowse_req(#httpdb{headers = BaseHeaders} = HttpDb, Params) ->
         lists:ukeymerge(1, get_value(ibrowse_options, Params, []),
             HttpDb#httpdb.ibrowse_options)
     ],
+    Timeout = case config:get("replicator", "request_timeout", "infinity") of
+        "infinity" -> infinity;
+        Milliseconds -> list_to_integer(Milliseconds)
+    end,
     Response = ibrowse:send_req_direct(
-        Worker, Url, Headers2, Method, Body, IbrowseOptions, infinity),
+        Worker, Url, Headers2, Method, Body, IbrowseOptions, Timeout),
     {Worker, Response}.
 
 


### PR DESCRIPTION
This is intended as a defensive measure against failures in code that's out
of our control, such as ibrowse.

BugzID: 20550
