### PR TITLE
Fix is_replicator_db_fun to allow usernames

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -682,7 +682,12 @@ scan_all_dbs(Server) when is_pid(Server) ->
     couch_db:close(Db).
 
 is_replicator_db_fun() ->
-    {ok, RegExp} = re:compile("^([a-z0-9][a-z0-9\\_\\$()\\+\\-\\/]*/)?_replicator$"),
-    fun(DbName) ->
-        match =:= re:run(mem3:dbname(DbName), RegExp, [{capture,none}])
+    fun(Name) ->
+        DbName = mem3:dbname(Name),
+        case lists:last(binary:split(DbName, <<"/">>, [global])) of
+            <<"_replicator">> ->
+                true;
+            _ ->
+                false
+        end
     end.


### PR DESCRIPTION
This updates couch_replicator:is_replicator_db_fun to allow for
usernames as valid replicator db names. This issue presented itself in
multi-homed replications where the username was a numeric username.

This change introduces two subtle issues, 1) this will no longer fully
validate on dbnames, as dbnames are not allowed to start with a number,
and 2) this will not properly validate on usernames as usernames are not
allowed to have all the special characters available to dbnames.

BugzID: 23315
