### PR TITLE
Bubble up missing_stub exceptions for proper retry

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -213,6 +213,8 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
     receive
         {'DOWN', Ref, process, Pid, {exit_ok, Ret}} ->
             Ret;
+        {'DOWN', Ref, process, Pid, {{nocatch, {missing_stub,_} = Stub}, _}} ->
+            throw(Stub);
         {'DOWN', Ref, process, Pid, Else} ->
             Url = couch_util:url_strip_password(
                 couch_replicator_httpc:full_url(HttpDb, [{path,Path}, {qs,QS}])


### PR DESCRIPTION
A missing_stub exception is special in that the replicator retries the request without the atts_since optimmization.

COUCHDB-1901
BugzID: 23982
