### PR TITLE
Catch/re-throw recurse exceptions and clean up http message queues

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -123,9 +123,11 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
                 Ret
             catch
                 throw:{maybe_retry_req, Err} ->
+                    release_worker(Worker, HttpDb),
                     clean_mailbox_req(ReqId),
                     maybe_retry(Err, Worker, HttpDb, Params, Callback);
                 throw:recurse ->
+                    release_worker(Worker, HttpDb),
                     clean_mailbox_req(ReqId),
                     throw(recurse)
             end;


### PR DESCRIPTION
When couch_replicator_changes_reader:process_change/2 throws in order to
recurse back in to another `_changes` request, the control flow passes
down the stack past couch_replicator_httpc:process_stream_response/5.
Unless we catch `throw:recurse` on the way down, the process will
be prevented from cleaning any remaining "end of stream" messages out
of its mailbox for the ReqId in process.

I've also added some additional calls to `clean_mailbox_req` for error cases;
I haven't observed them causing issues in production, but I can't see why it
isn't necessary.
