### PR TITLE
Retry if doc is missing

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -254,6 +254,8 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
     receive
         {'DOWN', Ref, process, Pid, {exit_ok, Ret}} ->
             Ret;
+        {'DOWN', Ref, process, Pid, {{nocatch, missing_doc}, _}} ->
+            throw(missing_doc);
         {'DOWN', Ref, process, Pid, {{nocatch, {missing_stub,_} = Stub}, _}} ->
             throw(Stub);
         {'DOWN', Ref, process, Pid, Else} ->

--- a/src/couch_replicator_worker.erl
+++ b/src/couch_replicator_worker.erl
@@ -295,6 +295,11 @@ fetch_doc(Source, {Id, Revs, PAs}, DocHandler, Acc) ->
         couch_replicator_api_wrap:open_doc_revs(
             Source, Id, Revs, [{atts_since, PAs}, latest], DocHandler, Acc)
     catch
+    throw:missing_doc ->
+        twig:log(error,"Retrying fetch and update of document `~s` as it is "
+            "unexpectedly missing. Missing revisions are: ~s",
+            [Id, couch_doc:revs_to_strs(Revs)]),
+        couch_replicator_api_wrap:open_doc_revs(Source, Id, Revs, [latest], DocHandler, Acc);
     throw:{missing_stub, _} ->
         twig:log(error,"Retrying fetch and update of document `~s` due to out of "
             "sync attachment stubs. Missing revisions are: ~s",
@@ -347,8 +352,8 @@ remote_doc_handler({ok, Doc}, {Parent, Target} = Acc) ->
     end,
     ok = gen_server:call(Parent, {add_stats, Stats2}, infinity),
     Result;
-remote_doc_handler(_, Acc) ->
-    {ok, Acc}.
+remote_doc_handler({{not_found, missing}, _}, _Acc) ->
+    throw(missing_doc).
 
 
 spawn_writer(Target, #batch{docs = DocList, size = Size}) ->


### PR DESCRIPTION
The catch-all clause in remote_doc_handler is the root cause of
missing updates in replication. This occurs when we receive a
`{{not_found,missing}, Rev}` message instead of the expected`{ok, Doc}`
message, and causes us to continue blindly on, including writing a
checkpoint.

This patch changes the catch-all clause to one that handles the
missing doc case and causes a retry. Any other response will be a
function_clause which will cause a messier retry.

BugzID: 31722
