### PR TITLE
Duplicate jobs transition directly to completed state

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -448,12 +448,12 @@ maybe_start_replication(State, DbName, DocId, RepDoc) ->
     #rep_state{starting = false, dbname = DbName, rep = #rep{doc_id = OtherDocId}} ->
         twig:log(notice, "The replication specified by the document `~s` was already"
             " triggered by the document `~s`", [DocId, OtherDocId]),
-        maybe_tag_rep_doc(DbName, DocId, RepDoc, ?l2b(BaseId)),
+        stop_duplicate(DbName, DocId, RepDoc, ?l2b(BaseId)),
         State;
     #rep_state{starting = true, dbname = DbName, rep = #rep{doc_id = OtherDocId}} ->
         twig:log(notice, "The replication specified by the document `~s` is already"
             " being triggered by the document `~s`", [DocId, OtherDocId]),
-        maybe_tag_rep_doc(DbName, DocId, RepDoc, ?l2b(BaseId)),
+        stop_duplicate(DbName, DocId, RepDoc, ?l2b(BaseId)),
         State
     end.
 
@@ -470,13 +470,12 @@ parse_rep_doc(RepDoc) ->
     Rep.
 
 
-maybe_tag_rep_doc(DbName, DocId, {RepProps}, RepId) ->
-    case get_value(<<"_replication_id">>, RepProps) of
-    RepId ->
-        ok;
-    _ ->
-        update_rep_doc(DbName, DocId, [{<<"_replication_id">>, RepId}])
-    end.
+stop_duplicate(DbName, DocId, {RepProps}, RepId) ->
+    update_rep_doc(DbName, DocId, [
+        {<<"_replication_id">>, RepId},
+        {<<"_replication_state">>, <<"completed">>},
+        {<<"_replication_state_reason">>, <<"duplicate">>}
+    ]).
 
 %% note to self: this is markedly diff from mem3_rep_manager
 start_replication(Rep, Wait) ->


### PR DESCRIPTION
_replicate is idempotent but _replicator is not, one can create any
number of documents with the same content. The burden of retrying all
the duplicates can be excessive.

A detected duplicate will now transition immediately to completed, as
we know there's a currently running job for the exact same task.

BugzID: 43505