### PR TITLE
Fix stream cleanup timeouts

### DIFF
--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -179,6 +179,8 @@ clean_mailbox({ibrowse_req_id, ReqId}) ->
                 {ibrowse_async_response_end, ReqId} ->
                     put(?STREAM_STATUS, ended),
                     ok
+                after 30000 ->
+                    exit({timeout, ibrowse_stream_cleanup})
             end;
         Status when Status == init; Status == ended ->
             receive
@@ -186,6 +188,8 @@ clean_mailbox({ibrowse_req_id, ReqId}) ->
                     clean_mailbox({ibrowse_req_id, ReqId});
                 {ibrowse_async_response_end, ReqId} ->
                     put(?STREAM_STATUS, ended),
+                    ok
+                after 0 ->
                     ok
             end
     end;


### PR DESCRIPTION
The first part of this is adding the `after 0` clause. The issue here is
that ibrowse sends the `ibrowse_async_response_end` message without
waiting for a call to `ibrowse:stream_next/1`. This means that the
continuous changes feed may or may not get this message in
`couch_replicator_httpc:accumulate_messages/3`. If it does then we would
end up on an infinite timeout waiting for it. This was a typo in the
original patch in that I meant to include it but forgot.

The second timeout is so that we don't end up halted waiting for a
changes request to finish. If it takes longer than 30s we just crash the
replication and let the manager restart things.

BugzId: 47306