### PR TITLE
Reduce checkpoint frequency from 5 to 30 seconds

### DIFF
--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -27,6 +27,8 @@
 
 -define(LOWEST_SEQ, 0).
 
+-define(DEFAULT_CHECKPOINT_INTERVAL, 30000).
+
 -include_lib("couch/include/couch_db.hrl").
 -include("couch_replicator_api_wrap.hrl").
 -include("couch_replicator.hrl").
@@ -73,7 +75,7 @@
     target_monitor = nil,
     source_seq = nil,
     use_checkpoints = true,
-    checkpoint_interval = 5000
+    checkpoint_interval = ?DEFAULT_CHECKPOINT_INTERVAL
 }).
 
 
@@ -612,7 +614,7 @@ init_state(Rep) ->
         source_monitor = db_monitor(Source),
         target_monitor = db_monitor(Target),
         use_checkpoints = get_value(use_checkpoints, Options, true),
-        checkpoint_interval = get_value(checkpoint_interval, Options, 5000)
+        checkpoint_interval = get_value(checkpoint_interval, Options, ?DEFAULT_CHECKPOINT_INTERVAL)
     },
     State#rep_state{timer = start_timer(State)}.
 

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -226,7 +226,7 @@ make_options(Props) ->
     DefTimeout = config:get("replicator", "connection_timeout", "30000"),
     DefRetries = config:get("replicator", "retries_per_request", "10"),
     UseCheckpoints = config:get("replicator", "use_checkpoints", "true"),
-    DefCheckpointInterval = config:get("replicator", "checkpoint_interval", "5000"),
+    DefCheckpointInterval = config:get("replicator", "checkpoint_interval", "30000"),
     {ok, DefSocketOptions} = couch_util:parse_term(
         config:get("replicator", "socket_options",
             "[{keepalive, true}, {nodelay, false}]")),


### PR DESCRIPTION
This should improve handling of a large number of replications.

Use a macro in a couple of places to avoid hard-coded
magic number.

BugzID: 63458
COUCHDB-2979