### PR TITLE
Handle 429 With BackOff

### DIFF
--- a/include/couch_replicator_api_wrap.hrl
+++ b/include/couch_replicator_api_wrap.hrl
@@ -24,7 +24,8 @@
     retries = 10,
     wait = 250,         % milliseconds
     httpc_pool = nil,
-    http_connections
+    http_connections,
+    backoff = 25
 }).
 
 -record(oauth, {

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -27,6 +27,9 @@
 
 -define(replace(L, K, V), lists:keystore(K, 1, L, {K, V})).
 -define(MAX_WAIT, 5 * 60 * 1000).
+-define(MAX_BACKOFF_WAIT, 250 * 32768).
+-define(MAX_BACKOFF_LOG_THRESHOLD, 512000).
+-define(BACKOFF_EXP, 1.5).
 -define(STREAM_STATUS, ibrowse_stream_status).
 
 
@@ -116,6 +119,8 @@ process_response({ibrowse_req_id, ReqId}, Worker, HttpDb, Params, Callback) ->
 
 process_response({ok, Code, Headers, Body}, Worker, HttpDb, Params, Callback) ->
     case list_to_integer(Code) of
+    429 ->
+        backoff(Worker, HttpDb, Params);
     Ok when (Ok >= 200 andalso Ok < 300) ; (Ok >= 400 andalso Ok < 500) ->
         couch_stats:increment_counter([couch_replicator, responses, success]),
         EJson = case Body of
@@ -140,6 +145,9 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
     receive
     {ibrowse_async_headers, ReqId, Code, Headers} ->
         case list_to_integer(Code) of
+        429 ->
+            backoff(Worker, HttpDb#httpdb{timeout = ?MAX_BACKOFF_WAIT},
+                Params);
         Ok when (Ok >= 200 andalso Ok < 300) ; (Ok >= 400 andalso Ok < 500) ->
             couch_stats:increment_counter(
                 [couch_replicator, stream_responses, success]),
@@ -226,19 +234,41 @@ clean_mailbox(_, Count) when Count > 0 ->
     ok.
 
 
+%% For 429 errors, we perform an exponential backoff up to 2.17 hours.
+%% We use Backoff time as a timeout/failure end.
+backoff(Worker, #httpdb{backoff = Backoff} = HttpDb, Params) ->
+    ok = timer:sleep(random:uniform(Backoff)),
+    Backoff2 = round(Backoff*?BACKOFF_EXP),
+    NewBackoff = erlang:min(Backoff2, ?MAX_BACKOFF_WAIT),
+    NewHttpDb = HttpDb#httpdb{backoff = NewBackoff},
+    case Backoff2 of
+        W0 when W0 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
+            log_retry_error(Params, HttpDb, Backoff2, "429 Retry"),
+            throw({retry, NewHttpDb, Params});
+        W1 when W1 > ?MAX_BACKOFF_WAIT ->
+            report_error(Worker, HttpDb, Params, {error,
+                "429 Retry Timeout"});
+        _ ->
+            throw({retry, NewHttpDb, Params})
+    end.
+
 maybe_retry(Error, Worker, #httpdb{retries = 0} = HttpDb, Params) ->
     report_error(Worker, HttpDb, Params, {error, Error});
 
 maybe_retry(Error, _Worker, #httpdb{retries = Retries, wait = Wait} = HttpDb,
     Params) ->
-    Method = string:to_upper(atom_to_list(get_value(method, Params, get))),
-    Url = couch_util:url_strip_password(full_url(HttpDb, Params)),
-    twig:log(notice,"Retrying ~s request to ~s in ~p seconds due to error ~s",
-        [Method, Url, Wait / 1000, error_cause(Error)]),
     ok = timer:sleep(Wait),
+    log_retry_error(Params, HttpDb, Wait, Error),
     Wait2 = erlang:min(Wait * 2, ?MAX_WAIT),
     NewHttpDb = HttpDb#httpdb{retries = Retries - 1, wait = Wait2},
     throw({retry, NewHttpDb, Params}).
+
+
+log_retry_error(Params, HttpDb, Wait, Error) ->
+    Method = string:to_upper(atom_to_list(get_value(method, Params, get))),
+    Url = couch_util:url_strip_password(full_url(HttpDb, Params)),
+    twig:log(notice, "Retrying ~s request to ~s in ~p seconds due to error ~s",
+        [Method, Url, Wait / 1000, error_cause(Error)]).
 
 
 report_error(_Worker, HttpDb, Params, Error) ->


### PR DESCRIPTION
When we encounter a 429, we retry with a different set of retries and
timeout. This will theoretically reduce client replication overload.
When 429s have stopped, it's possible that a 500 error could occur.
Then the retry mechanism should go back to the original way for
backwards compatibility.

Moving this from https://github.com/apache/couchdb-couch-replicator/pull/40 since ASF is currently in a code freeze.

Tested with https://github.com/cloudant/dyno  and also
https://github.com/cloudant/testy/blob/master/suites/replication/test_continuous_replication.py

against a target ccm server