### PR TITLE
Retrieve headers case-insensitivity

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -220,7 +220,7 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
         Callback = fun(200, Headers, StreamDataFun) ->
             remote_open_doc_revs_streamer_start(Self),
             {<<"--">>, _, _} = couch_httpd:parse_multipart_request(
-                get_value("Content-Type", Headers),
+                header_value("Content-Type", Headers),
                 StreamDataFun,
                 fun mp_parse_mixed/1
             )
@@ -620,7 +620,7 @@ receive_docs(Streamer, UserFun, Ref, UserAcc) ->
     {started_open_doc_revs, NewRef} ->
         restart_remote_open_doc_revs(Ref, NewRef);
     {headers, Ref, Headers} ->
-        case get_value("content-type", Headers) of
+        case header_value("content-type", Headers) of
         {"multipart/related", _} = ContentType ->
             case doc_from_multi_part_stream(
                 ContentType,
@@ -922,4 +922,16 @@ stream_doc({LenLeft, Id}) when LenLeft > 0 ->
     erlang:get({doc_streamer, Id}) ! {get_data, Ref, self()},
     receive {data, Ref, Data} ->
         {ok, Data, {LenLeft - iolist_size(Data), Id}}
+    end.
+
+header_value(Key, Headers) ->
+    header_value(Key, Headers, undefined).
+
+header_value(Key, Headers, Default) ->
+    Headers1 = [{string:to_lower(K), V} || {K, V} <- Headers],
+    case lists:keyfind(string:to_lower(Key), 1, Headers1) of
+        {_, Value} ->
+            Value;
+        _ ->
+            Default
     end.


### PR DESCRIPTION
This ports over fix COUCHDB-1637 to address when Content-Type is lower
case and the call to get_value returns undefined.

BugzId: 68385