### PR TITLE
Backport Commits From Dbnext

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -433,33 +433,42 @@ changes_since(#httpdb{headers = Headers1, timeout = InactiveTimeout} = HttpDb,
         JsonDocIds = ?JSON_ENCODE({[{<<"doc_ids">>, DocIds}]}),
         {[{"filter", "_doc_ids"} | BaseQArgs], post, JsonDocIds, Headers2}
     end,
-    send_req(
-        HttpDb,
-        [{method, Method}, {path, "_changes"}, {qs, QArgs},
-            {headers, Headers}, {body, Body},
-            {ibrowse_options, [{stream_to, {self(), once}}]}],
-        fun(200, _, DataStreamFun) ->
-                parse_changes_feed(Options, UserFun, DataStreamFun);
-            (405, _, _) when is_list(DocIds) ->
-                % CouchDB versions < 1.1.0 don't have the builtin _changes feed
-                % filter "_doc_ids" neither support POST
-                send_req(HttpDb, [{method, get}, {path, "_changes"},
-                    {qs, BaseQArgs}, {headers, Headers1},
-                    {ibrowse_options, [{stream_to, {self(), once}}]}],
-                    fun(200, _, DataStreamFun2) ->
-                        UserFun2 = fun(#doc_info{id = Id} = DocInfo) ->
-                            case lists:member(Id, DocIds) of
-                            true ->
-                                UserFun(DocInfo);
-                            false ->
-                                ok
-                            end;
-                        (LastSeq) ->
-                            UserFun(LastSeq)
-                        end,
-                        parse_changes_feed(Options, UserFun2, DataStreamFun2)
-                    end)
-        end);
+    try
+        send_req(
+            HttpDb,
+            [{method, Method}, {path, "_changes"}, {qs, QArgs},
+                {headers, Headers}, {body, Body},
+                {ibrowse_options, [{stream_to, {self(), once}}]}],
+            fun(200, _, DataStreamFun) ->
+                    parse_changes_feed(Options, UserFun, DataStreamFun);
+                (405, _, _) when is_list(DocIds) ->
+                    % CouchDB versions < 1.1.0 don't have the builtin
+                    % _changes feed filter "_doc_ids" neither support POST
+                    send_req(HttpDb, [{method, get}, {path, "_changes"},
+                        {qs, BaseQArgs}, {headers, Headers1},
+                        {ibrowse_options, [{stream_to, {self(), once}}]}],
+                        fun(200, _, DataStreamFun2) ->
+                            UserFun2 = fun(#doc_info{id = Id} = DocInfo) ->
+                                case lists:member(Id, DocIds) of
+                                true ->
+                                    UserFun(DocInfo);
+                                false ->
+                                    ok
+                                end;
+                            (LastSeq) ->
+                                UserFun(LastSeq)
+                            end,
+                            parse_changes_feed(Options, UserFun2,
+                                DataStreamFun2)
+                        end)
+            end)
+    catch
+        exit:{http_request_failed, _, _, {error, {connection_closed,
+                mid_stream}}} ->
+            throw(retry_no_limit);
+        exit:{http_request_failed, _, _, _} = Error ->
+            throw({retry_limit, Error})
+    end;
 changes_since(Db, Style, StartSeq, UserFun, Options) ->
     Filter = case get_value(doc_ids, Options) of
     undefined ->

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -160,6 +160,9 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
                 Ret = Callback(Ok, Headers, StreamDataFun),
                 Ret
             catch
+                throw:{maybe_retry_req, connection_closed} ->
+                    maybe_retry({connection_closed, mid_stream},
+                        Worker, HttpDb, Params);
                 throw:{maybe_retry_req, Err} ->
                     maybe_retry(Err, Worker, HttpDb, Params)
             end;

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -255,12 +255,12 @@ backoff(Worker, #httpdb{backoff = Backoff} = HttpDb, Params) ->
     NewBackoff = erlang:min(Backoff2, ?MAX_BACKOFF_WAIT),
     NewHttpDb = HttpDb#httpdb{backoff = NewBackoff},
     case Backoff2 of
-        W0 when W0 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
+        W0 when W0 > ?MAX_BACKOFF_WAIT ->
+            report_error(Worker, HttpDb, Params, {error,
+                "Long 429-induced Retry Time Out"});
+        W1 when W1 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
             log_retry_error(Params, HttpDb, Backoff2, "429 Retry"),
             throw({retry, NewHttpDb, Params});
-        W1 when W1 > ?MAX_BACKOFF_WAIT ->
-            report_error(Worker, HttpDb, Params, {error,
-                "429 Retry Timeout"});
         _ ->
             throw({retry, NewHttpDb, Params})
     end.


### PR DESCRIPTION
Since some clusters will still be on dbcore when ccm is enabled, we need to backport the following commits that were discovered during testing of 429 that also need to be fixed for dbcore:

https://github.com/cloudant/couchdb-couch-replicator/commit/bf636d3088e39e392517117e4e5ed4e22f8f7e34

https://github.com/cloudant/couchdb-couch-replicator/commit/5c808e92cfaf9920b1d54a4249470e86b8408401

https://github.com/cloudant/couchdb-couch-replicator/commit/cd932bf8cc984196bc369576a4b8d6ca018420a3

I ran the same tests for dbcore as dbnext and they were successful.