### PR TITLE
Change Httpdb Record to Support Hot Upgrades

### DIFF
--- a/include/couch_replicator_api_wrap.hrl
+++ b/include/couch_replicator_api_wrap.hrl
@@ -22,10 +22,9 @@
     timeout,            % milliseconds
     ibrowse_options = [],
     retries = 10,
-    wait = 250,         % milliseconds
+    wait = {250, 25},  % {normal error wait time, 429 backoff wait time}
     httpc_pool = nil,
-    http_connections,
-    backoff = 25
+    http_connections
 }).
 
 -record(oauth, {

--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -49,7 +49,7 @@
     get_value/3
     ]).
 
--define(MAX_WAIT, 5 * 60 * 1000).
+-define(MAX_WAIT, 10 * 60 * 1000).
 
 db_uri(#httpdb{url = Url}) ->
     couch_util:url_strip_password(Url);
@@ -270,7 +270,7 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
                 couch_replicator_httpc:full_url(HttpDb, [{path,Path}, {qs,QS}])
             ),
             #httpdb{retries = Retries, wait = Wait0} = HttpDb,
-            Wait = 2 * erlang:min(Wait0 * 2, ?MAX_WAIT),
+            Wait = erlang:min(Wait0 * 2, ?MAX_WAIT),
             twig:log(notice,"Retrying GET to ~s in ~p seconds due to error ~w",
                 [Url, Wait / 1000, Else]
             ),

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -18,6 +18,7 @@
 -export([replication_id/2]).
 -export([sum_stats/2, is_deleted/1]).
 -export([mp_parse_doc/2]).
+-export([maybe_upgrade_wait/1]).
 
 -export([handle_db_event/3]).
 
@@ -426,3 +427,9 @@ is_deleted(Change) ->
     Else ->
         Else
     end.
+
+% This is to support hot upgrades for 429 backoff
+maybe_upgrade_wait(#httpdb{wait = W} = HttpDb) when is_integer(W) ->
+    HttpDb#httpdb{wait = {W, 25}};
+maybe_upgrade_wait(HttpDb) ->
+    HttpDb.


### PR DESCRIPTION
1) Tested with dyno. Did not see any function_clause, badargs, or badmatch errors in splunk.
I ran a long replication job and in the middle performed the upgrade. The replication still completed.
I did see a few changes_reader and changes_manager process exits, but I think that occurs
when we do 
```
clou cluster make_permanent testy017 2608
```

2) Also ran regression with the ccm code against a ccm enabled cluster to make sure we didn't break anything.