### PR TITLE
Backport a bugfix and latest replication ID algorithms

### DIFF
--- a/include/couch_replicator.hrl
+++ b/include/couch_replicator.hrl
@@ -10,7 +10,7 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--define(REP_ID_VERSION, 2).
+-define(REP_ID_VERSION, 4).
 
 -record(rep, {
     id,

--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -654,7 +654,7 @@ maybe_save_migrated_log(Rep, Db, #doc{} = Doc, OldId) ->
         true ->
             update_checkpoint(Db, Doc),
             Msg = "Migrated replication checkpoint. Db:~p ~p -> ~p",
-            twig:log(error, Msg, [httpdb_strip_creds(Db), OldId, Doc#doc.id]);
+            twig:log(notice, Msg, [httpdb_strip_creds(Db), OldId, Doc#doc.id]);
         false ->
             ok
     end.

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -63,6 +63,18 @@ replication_id(#rep{options = Options} = Rep) ->
 % If a change is made to how replications are identified,
 % please add a new clause and increase ?REP_ID_VERSION.
 
+replication_id(#rep{user_ctx = UserCtx} = Rep, 4) ->
+    UUID = get_couch_server_uuid(),
+    SrcInfo = get_v4_endpoint(UserCtx, Rep#rep.source),
+    TgtInfo = get_v4_endpoint(UserCtx, Rep#rep.target),
+    maybe_append_filters([UUID, SrcInfo, TgtInfo], Rep);
+
+replication_id(#rep{user_ctx = UserCtx} = Rep, 3) ->
+    UUID = get_couch_server_uuid(),
+    Src = get_rep_endpoint(UserCtx, Rep#rep.source),
+    Tgt = get_rep_endpoint(UserCtx, Rep#rep.target),
+    maybe_append_filters([UUID, Src, Tgt], Rep);
+
 replication_id(#rep{user_ctx = UserCtx} = Rep, 2) ->
     {ok, HostName} = inet:gethostname(),
     Port = case (catch mochiweb_socket_server:get(couch_httpd, port)) of
@@ -433,3 +445,93 @@ maybe_upgrade_wait(#httpdb{wait = W} = HttpDb) when is_integer(W) ->
     HttpDb#httpdb{wait = {W, 25}};
 maybe_upgrade_wait(HttpDb) ->
     HttpDb.
+
+
+% DBNext has couch_server:get_uuid() function to get the UUID of the cluster
+% DBCore doesn't use that feature. Here it is read directly from config
+% setting and used only for forward compatibility
+get_couch_server_uuid() ->
+    config:get("couchdb", "uuid").
+
+
+get_v4_endpoint(UserCtx, #httpdb{} = HttpDb) ->
+    {Url, Headers, OAuth} = case get_rep_endpoint(UserCtx, HttpDb) of
+        {remote, U, Hds} ->
+            {U, Hds, undefined};
+        {remote, U, Hds, OA} ->
+            {U, Hds, OA}
+    end,
+    {UserFromHeaders, HeadersWithoutBasicAuth} = remove_basic_auth(Headers),
+    {UserFromUrl, Host, NonDefaultPort, Path} = get_v4_url_info(Url),
+    User = pick_defined_value([UserFromUrl, UserFromHeaders]),
+    {remote, User, Host, NonDefaultPort, Path, HeadersWithoutBasicAuth, OAuth};
+get_v4_endpoint(UserCtx, <<DbName/binary>>) ->
+    {local, DbName, UserCtx}.
+
+
+remove_basic_auth(Headers) ->
+    case lists:partition(fun is_basic_auth/1, Headers) of
+        {[], HeadersWithoutBasicAuth} ->
+            {undefined, HeadersWithoutBasicAuth};
+        {[{_, "Basic " ++ Base64} | _], HeadersWithoutBasicAuth} ->
+            User = get_basic_auth_user(Base64),
+            {User, HeadersWithoutBasicAuth}
+    end.
+
+
+is_basic_auth({"Authorization", "Basic " ++ _Base64}) ->
+    true;
+is_basic_auth(_) ->
+    false.
+
+
+get_basic_auth_user(Base64) ->
+    try re:split(base64:decode(Base64), ":", [{return, list}, {parts, 2}]) of
+        [User, _Pass] ->
+            User;
+        _ ->
+            undefined
+    catch
+        % Tolerate invalid B64 values here to avoid crashing replicator
+        error:function_clause ->
+            undefined
+    end.
+
+
+pick_defined_value(Values) ->
+    case [V || V <- Values, V /= undefined] of
+        [] ->
+            undefined;
+        DefinedValues ->
+            hd(DefinedValues)
+    end.
+
+
+get_v4_url_info(Url) when is_binary(Url) ->
+    get_v4_url_info(binary_to_list(Url));
+get_v4_url_info(Url) ->
+    case ibrowse_lib:parse_url(Url) of
+        {error, invalid_uri} ->
+            % Tolerate errors here to avoid a bad user document
+            % crashing the replicator
+            {undefined, Url, undefined, undefined};
+        #url{
+            protocol = Schema,
+            username = User,
+            host = Host,
+            port = Port,
+            path = Path
+        } ->
+            NonDefaultPort = get_non_default_port(Schema, Port),
+            {User, Host, NonDefaultPort, Path}
+    end.
+
+
+get_non_default_port(https, 443) ->
+    default;
+get_non_default_port(http, 80) ->
+    default;
+get_non_default_port(http, 5984) ->
+    default;
+get_non_default_port(_Schema, Port) ->
+    Port.


### PR DESCRIPTION
Backport latest replication ID algorithms from DBNext

There are 2 commits:

1. Backport V3 and V4 with associated helper functions.

2. Backport a bug fix which ensures when replication checkpoints are migrated to a new version, they are immediately persisted to target and source. Previously that only happened after the source was updated.