### PR TITLE
Fix bug replicating from a node-local source database

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -161,9 +161,9 @@ get_pending_count(#httpdb{} = Db, Seq) ->
         {ok, couch_util:get_value(<<"pending">>, Props, null)}
     end);
 get_pending_count(#db{name=DbName}=Db, Seq) when is_number(Seq) ->
-    {ok, Db} = couch_db:open(DbName, [{user_ctx, Db#db.user_ctx}]),
-    Pending = couch_db:count_changes_since(Db, Seq),
-    couch_db:close(Db),
+    {ok, CountDb} = couch_db:open(DbName, [{user_ctx, Db#db.user_ctx}]),
+    Pending = couch_db:count_changes_since(CountDb, Seq),
+    couch_db:close(CountDb),
     {ok, Pending}.
 
 


### PR DESCRIPTION
Previously `Db` variable was matched erroneously when opened, so use a
different handle name.

BugzID: 94208