### PR TITLE
Configurable delay before retrying on missing_doc error

### DIFF
--- a/src/couch_replicator_worker.erl
+++ b/src/couch_replicator_worker.erl
@@ -31,6 +31,7 @@
 -define(MAX_BULK_ATT_SIZE, 64 * 1024).
 -define(MAX_BULK_ATTS_PER_DOC, 8).
 -define(STATS_DELAY, 10000000).              % 10 seconds (in microseconds)
+-define(MISSING_DOC_RETRY_MSEC, 2000).
 
 -import(couch_replicator_utils, [
     open_db/1,
@@ -299,11 +300,17 @@ fetch_doc(Source, {Id, Revs, PAs}, DocHandler, Acc) ->
         twig:log(error,"Retrying fetch and update of document `~s` as it is "
             "unexpectedly missing. Missing revisions are: ~s",
             [Id, couch_doc:revs_to_strs(Revs)]),
+        WaitMSec = config:get_integer("replicator", "missing_doc_retry_msec",
+            ?MISSING_DOC_RETRY_MSEC),
+        timer:sleep(WaitMSec),
         couch_replicator_api_wrap:open_doc_revs(Source, Id, Revs, [latest], DocHandler, Acc);
     throw:{missing_stub, _} ->
         twig:log(error,"Retrying fetch and update of document `~s` due to out of "
             "sync attachment stubs. Missing revisions are: ~s",
             [Id, couch_doc:revs_to_strs(Revs)]),
+        WaitMSec = config:get_integer("replicator", "missing_doc_retry_msec",
+            ?MISSING_DOC_RETRY_MSEC),
+        timer:sleep(WaitMSec),
         couch_replicator_api_wrap:open_doc_revs(Source, Id, Revs, [latest], DocHandler, Acc)
     end.
 


### PR DESCRIPTION
Implement a configurable delay before retrying a document fetch in replicator.

missing_doc exceptions usually happen when there is a continuous replication
set up and the source is updated. The change might appear in the changes feed,
but when worker tries to fetch the document's revisions it talks to a
node where internal replication hasn't caught up and so it throws an exception.

Previously the delay was hard-coded at 0 (that is retrying was immediate). The
replication would still make progress, but after crashing, retrying and
generating a lot of unnecessary log noise. Since updating a source while
continuous replication is running is a common scenario, it's worth optimizing
for it and avoiding wasting resources and spamming logs.

This is a backport of CouchDB commit:

https://github.com/apache/couchdb/commit/40b9f85f0be775fe5508f12332130f2695262595