### PR TITLE
Make sure replicator's V4 version uses a binary server UUID value

### DIFF
--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -451,7 +451,12 @@ maybe_upgrade_wait(HttpDb) ->
 % DBCore doesn't use that feature. Here it is read directly from config
 % setting and used only for forward compatibility
 get_couch_server_uuid() ->
-    config:get("couchdb", "uuid").
+    case config:get("couchdb", "uuid") of
+        UUID when is_list(UUID) ->
+            ?l2b(UUID);
+        undefined ->
+            undefined
+    end.
 
 
 get_v4_endpoint(UserCtx, #httpdb{} = HttpDb) ->


### PR DESCRIPTION
Previously it returned the value from config:get which was a
list. Since the whole term was hashed it produced a replication ID
which did not not match the replication ID in DBNext and result a
changes feed rewind.

See https://github.com/apache/couchdb/blob/master/src/couch/src/couch_server.erl#L63 for reference.